### PR TITLE
use functions to handle bindfs umount tool output more flexibly

### DIFF
--- a/internal/workspace/localInstall.go
+++ b/internal/workspace/localInstall.go
@@ -187,7 +187,7 @@ func (ws *Workspace) uninstall(pkg string, logWriter io.Writer, indent string) e
 		outputBuff := &bytes.Buffer{}
 
 		var cmd *exec.Cmd
-		var notMountedOutput string
+		var notMounted func(output, pkgSrc string) bool
 
 		hasFusermount, err := commandExists("fusermount")
 		if err != nil {
@@ -197,19 +197,20 @@ func (ws *Workspace) uninstall(pkg string, logWriter io.Writer, indent string) e
 		if hasFusermount {
 			// Use fusermount if that exists
 			cmd = exec.Command("fusermount", "-u", pkgSrc)
-			notMountedOutput = fmt.Sprintf("fusermount: entry for %s not found", pkgSrc)
+			notMounted = fusermountNotMounted
 		} else {
 			// Otherwise fallback to umount
 			cmd = exec.Command("umount", pkgSrc)
-			notMountedOutput = fmt.Sprintf("umount: %s: not mounted", pkgSrc)
+			notMounted = umountNotMounted
 		}
 
 		cmd.Stderr = io.MultiWriter(stderrBuff, outputBuff)
 		cmd.Stdout = outputBuff
 
 		err = cmd.Run()
+
 		if err != nil {
-			if !strings.HasPrefix(stderrBuff.String(), notMountedOutput) {
+			if !notMounted(stderrBuff.String(), pkgSrc) {
 				// We don't care if the write to stderr failed
 				_, _ = io.Copy(os.Stderr, outputBuff)
 
@@ -272,6 +273,14 @@ func (ws *Workspace) uninstall(pkg string, logWriter io.Writer, indent string) e
 		}
 	}
 	return nil
+}
+
+func umountNotMounted(output, pkgSrc string) bool {
+	return strings.HasPrefix(output, fmt.Sprintf("umount: %s: not currently mounted", pkgSrc)) || strings.HasPrefix(output, fmt.Sprintf("umount: %s: not mounted", pkgSrc))
+}
+
+func fusermountNotMounted(output, pkgSrc string) bool {
+	return strings.HasPrefix(output, fmt.Sprintf("fusermount: entry for %s not found", pkgSrc))
 }
 
 func (ws *Workspace) ClearSrc() error {


### PR DESCRIPTION
The output of my OSX bindfs umount was slightly different to that
expected by vg localInstall, so activation failed.

Not yet tested on fusermount.