### PR TITLE
Travis upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ go:
   - 1.9.x
   - 1.10rc1
 
-dist: trusty
-sudo: false
-
 before_install:
   - go get github.com/GetStream/vg
   - go get github.com/golang/dep/cmd/dep


### PR DESCRIPTION
Upgrading travis configuration due to upcoming infrastructure changes - https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

* remove sudo:false and system version requirement